### PR TITLE
Add typescript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "1.0.2",
   "description": "Takes ProseMirror JSON and outputs HTML",
   "main": "index.js",
+  "types": "./types/index.d.ts",
   "scripts": {
-    "test": "mocha --recursive"
+    "test": "mocha --recursive",
+    "types": "tsc"
   },
   "keywords": [
     "prosemirror",
@@ -12,9 +14,9 @@
   ],
   "author": "Ashwani Agarwal",
   "license": "ISC",
-  "dependencies": {},
   "devDependencies": {
     "chai": "^4.2.0",
-    "mocha": "^6.2.0"
+    "mocha": "^6.2.0",
+    "typescript": "^4.9.4"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "include": ["index.js", "src/**/*"],
+  "compilerOptions": {
+    // Tells TypeScript to read JS files, as
+    // normally they are ignored as source files
+    "allowJs": true,
+    // Generate d.ts files
+    "declaration": true,
+    // This compiler run should
+    // only output d.ts files
+    "emitDeclarationOnly": true,
+    // Types should go into this directory.
+    // Removing this would place the .d.ts files
+    // next to the .js files
+    "outDir": "types",
+    // go to js file when using IDE functions like
+    // "Go to Definition" in VSCode
+    "declarationMap": true
+  }
+}

--- a/types/Marks/Bold.d.ts
+++ b/types/Marks/Bold.d.ts
@@ -1,0 +1,6 @@
+export = Bold;
+declare class Bold extends Mark {
+    tag(): string;
+}
+import Mark = require("./Mark");
+//# sourceMappingURL=Bold.d.ts.map

--- a/types/Marks/Bold.d.ts.map
+++ b/types/Marks/Bold.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Bold.d.ts","sourceRoot":"","sources":["../../src/Marks/Bold.js"],"names":[],"mappings":";AAEA;IAKI,cAEC;CACJ"}

--- a/types/Marks/Code.d.ts
+++ b/types/Marks/Code.d.ts
@@ -1,0 +1,6 @@
+export = Code;
+declare class Code extends Mark {
+    tag(): string;
+}
+import Mark = require("./Mark");
+//# sourceMappingURL=Code.d.ts.map

--- a/types/Marks/Code.d.ts.map
+++ b/types/Marks/Code.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Code.d.ts","sourceRoot":"","sources":["../../src/Marks/Code.js"],"names":[],"mappings":";AAEA;IAKI,cAEC;CACJ"}

--- a/types/Marks/Italic.d.ts
+++ b/types/Marks/Italic.d.ts
@@ -1,0 +1,6 @@
+export = Italic;
+declare class Italic extends Mark {
+    tag(): string;
+}
+import Mark = require("./Mark");
+//# sourceMappingURL=Italic.d.ts.map

--- a/types/Marks/Italic.d.ts.map
+++ b/types/Marks/Italic.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Italic.d.ts","sourceRoot":"","sources":["../../src/Marks/Italic.js"],"names":[],"mappings":";AAEA;IAKI,cAEC;CACJ"}

--- a/types/Marks/Link.d.ts
+++ b/types/Marks/Link.d.ts
@@ -1,0 +1,11 @@
+export = Link;
+declare class Link extends Mark {
+    tag(): {
+        tag: string;
+        attrs: {
+            href: any;
+        };
+    }[];
+}
+import Mark = require("./Mark");
+//# sourceMappingURL=Link.d.ts.map

--- a/types/Marks/Link.d.ts.map
+++ b/types/Marks/Link.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Link.d.ts","sourceRoot":"","sources":["../../src/Marks/Link.js"],"names":[],"mappings":";AAEA;IAKI;;;;;QASC;CACJ"}

--- a/types/Marks/Mark.d.ts
+++ b/types/Marks/Mark.d.ts
@@ -1,0 +1,8 @@
+export = Mark;
+declare class Mark {
+    constructor(mark: any);
+    mark: any;
+    matching(): boolean;
+    tag(): any;
+}
+//# sourceMappingURL=Mark.d.ts.map

--- a/types/Marks/Mark.d.ts.map
+++ b/types/Marks/Mark.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Mark.d.ts","sourceRoot":"","sources":["../../src/Marks/Mark.js"],"names":[],"mappings":";AAAA;IACI,uBAEC;IADG,UAAgB;IAGpB,oBAEC;IAED,WAEC;CACJ"}

--- a/types/Nodes/Blockquote.d.ts
+++ b/types/Nodes/Blockquote.d.ts
@@ -1,0 +1,6 @@
+export = Blockquote;
+declare class Blockquote extends Node {
+    tag(): string;
+}
+import Node = require("./Node");
+//# sourceMappingURL=Blockquote.d.ts.map

--- a/types/Nodes/Blockquote.d.ts.map
+++ b/types/Nodes/Blockquote.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Blockquote.d.ts","sourceRoot":"","sources":["../../src/Nodes/Blockquote.js"],"names":[],"mappings":";AAEA;IAKI,cAEC;CACJ"}

--- a/types/Nodes/BulletList.d.ts
+++ b/types/Nodes/BulletList.d.ts
@@ -1,0 +1,6 @@
+export = BulletList;
+declare class BulletList extends Node {
+    tag(): string;
+}
+import Node = require("./Node");
+//# sourceMappingURL=BulletList.d.ts.map

--- a/types/Nodes/BulletList.d.ts.map
+++ b/types/Nodes/BulletList.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"BulletList.d.ts","sourceRoot":"","sources":["../../src/Nodes/BulletList.js"],"names":[],"mappings":";AAEA;IAKI,cAEC;CACJ"}

--- a/types/Nodes/CodeBlock.d.ts
+++ b/types/Nodes/CodeBlock.d.ts
@@ -1,0 +1,8 @@
+export = CodeBlock;
+declare class CodeBlock extends Node {
+    tag(): {
+        tag: string;
+    }[];
+}
+import Node = require("./Node");
+//# sourceMappingURL=CodeBlock.d.ts.map

--- a/types/Nodes/CodeBlock.d.ts.map
+++ b/types/Nodes/CodeBlock.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"CodeBlock.d.ts","sourceRoot":"","sources":["../../src/Nodes/CodeBlock.js"],"names":[],"mappings":";AAEA;IAKI;;QASC;CACJ"}

--- a/types/Nodes/Heading.d.ts
+++ b/types/Nodes/Heading.d.ts
@@ -1,0 +1,6 @@
+export = Heading;
+declare class Heading extends Node {
+    tag(): string;
+}
+import Node = require("./Node");
+//# sourceMappingURL=Heading.d.ts.map

--- a/types/Nodes/Heading.d.ts.map
+++ b/types/Nodes/Heading.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Heading.d.ts","sourceRoot":"","sources":["../../src/Nodes/Heading.js"],"names":[],"mappings":";AAEA;IAKI,cAEC;CACJ"}

--- a/types/Nodes/Image.d.ts
+++ b/types/Nodes/Image.d.ts
@@ -1,0 +1,13 @@
+export = Image;
+declare class Image extends Node {
+    tag(): {
+        tag: string;
+        attrs: {
+            src: any;
+            alt: any;
+            title: any;
+        };
+    };
+}
+import Node = require("./Node");
+//# sourceMappingURL=Image.d.ts.map

--- a/types/Nodes/Image.d.ts.map
+++ b/types/Nodes/Image.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Image.d.ts","sourceRoot":"","sources":["../../src/Nodes/Image.js"],"names":[],"mappings":";AAEA;IASI;;;;;;;MASC;CACJ"}

--- a/types/Nodes/ListItem.d.ts
+++ b/types/Nodes/ListItem.d.ts
@@ -1,0 +1,6 @@
+export = ItemList;
+declare class ItemList extends Node {
+    tag(): string;
+}
+import Node = require("./Node");
+//# sourceMappingURL=ListItem.d.ts.map

--- a/types/Nodes/ListItem.d.ts.map
+++ b/types/Nodes/ListItem.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"ListItem.d.ts","sourceRoot":"","sources":["../../src/Nodes/ListItem.js"],"names":[],"mappings":";AAEA;IAKI,cAEC;CACJ"}

--- a/types/Nodes/Node.d.ts
+++ b/types/Nodes/Node.d.ts
@@ -1,0 +1,10 @@
+export = Node;
+declare class Node {
+    constructor(node: any);
+    node: any;
+    matching(): boolean;
+    selfClosing(): boolean;
+    tag(): any;
+    text(): any;
+}
+//# sourceMappingURL=Node.d.ts.map

--- a/types/Nodes/Node.d.ts.map
+++ b/types/Nodes/Node.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Node.d.ts","sourceRoot":"","sources":["../../src/Nodes/Node.js"],"names":[],"mappings":";AAAA;IACI,uBAEC;IADG,UAAgB;IAGpB,oBAEC;IAED,uBAEC;IAED,WAEC;IAED,YAEC;CACJ"}

--- a/types/Nodes/OrderedList.d.ts
+++ b/types/Nodes/OrderedList.d.ts
@@ -1,0 +1,6 @@
+export = OrderedList;
+declare class OrderedList extends Node {
+    tag(): string;
+}
+import Node = require("./Node");
+//# sourceMappingURL=OrderedList.d.ts.map

--- a/types/Nodes/OrderedList.d.ts.map
+++ b/types/Nodes/OrderedList.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"OrderedList.d.ts","sourceRoot":"","sources":["../../src/Nodes/OrderedList.js"],"names":[],"mappings":";AAEA;IAKI,cAEC;CACJ"}

--- a/types/Nodes/Paragraph.d.ts
+++ b/types/Nodes/Paragraph.d.ts
@@ -1,0 +1,6 @@
+export = Paragraph;
+declare class Paragraph extends Node {
+    tag(): string;
+}
+import Node = require("./Node");
+//# sourceMappingURL=Paragraph.d.ts.map

--- a/types/Nodes/Paragraph.d.ts.map
+++ b/types/Nodes/Paragraph.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Paragraph.d.ts","sourceRoot":"","sources":["../../src/Nodes/Paragraph.js"],"names":[],"mappings":";AAEA;IAKI,cAEC;CACJ"}

--- a/types/Renderer.d.ts
+++ b/types/Renderer.d.ts
@@ -1,0 +1,16 @@
+export = Renderer;
+declare class Renderer {
+    document: any;
+    nodes: (typeof import("./Nodes/Blockquote") | typeof import("./Nodes/CodeBlock") | typeof import("./Nodes/Image"))[];
+    marks: (typeof import("./Marks/Bold") | typeof import("./Marks/Link"))[];
+    setDocument(value: any): void;
+    renderNode(node: any): any;
+    renderOpeningTag(tags: any): any;
+    renderClosingTag(tags: any): any;
+    render(value: any): string;
+    addNode(node: any): void;
+    addNodes(nodes: any): void;
+    addMark(mark: any): void;
+    addMarks(marks: any): void;
+}
+//# sourceMappingURL=Renderer.d.ts.map

--- a/types/Renderer.d.ts.map
+++ b/types/Renderer.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Renderer.d.ts","sourceRoot":"","sources":["../src/Renderer.js"],"names":[],"mappings":";AAEA;IAEQ,cAAyB;IACzB,qHASC;IACD,yEAKC;IAGL,8BAQC;IAED,2BAkEC;IAED,iCAwBC;IAED,iCAeC;IAED,2BAWC;IAED,yBAEC;IAED,2BAIC;IAED,yBAEC;IAED,2BAIC;CACJ"}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,4 @@
+export const Renderer: typeof import("./src/Renderer");
+export const Node: typeof import("./src/Nodes/Node");
+export const Mark: typeof import("./src/Marks/Mark");
+//# sourceMappingURL=index.d.ts.map

--- a/types/index.d.ts.map
+++ b/types/index.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../index.js"],"names":[],"mappings":""}

--- a/types/src/Marks/Bold.d.ts
+++ b/types/src/Marks/Bold.d.ts
@@ -1,0 +1,6 @@
+export = Bold;
+declare class Bold extends Mark {
+    tag(): string;
+}
+import Mark = require("./Mark");
+//# sourceMappingURL=Bold.d.ts.map

--- a/types/src/Marks/Bold.d.ts.map
+++ b/types/src/Marks/Bold.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Bold.d.ts","sourceRoot":"","sources":["../../../src/Marks/Bold.js"],"names":[],"mappings":";AAEA;IAKI,cAEC;CACJ"}

--- a/types/src/Marks/Code.d.ts
+++ b/types/src/Marks/Code.d.ts
@@ -1,0 +1,6 @@
+export = Code;
+declare class Code extends Mark {
+    tag(): string;
+}
+import Mark = require("./Mark");
+//# sourceMappingURL=Code.d.ts.map

--- a/types/src/Marks/Code.d.ts.map
+++ b/types/src/Marks/Code.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Code.d.ts","sourceRoot":"","sources":["../../../src/Marks/Code.js"],"names":[],"mappings":";AAEA;IAKI,cAEC;CACJ"}

--- a/types/src/Marks/Italic.d.ts
+++ b/types/src/Marks/Italic.d.ts
@@ -1,0 +1,6 @@
+export = Italic;
+declare class Italic extends Mark {
+    tag(): string;
+}
+import Mark = require("./Mark");
+//# sourceMappingURL=Italic.d.ts.map

--- a/types/src/Marks/Italic.d.ts.map
+++ b/types/src/Marks/Italic.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Italic.d.ts","sourceRoot":"","sources":["../../../src/Marks/Italic.js"],"names":[],"mappings":";AAEA;IAKI,cAEC;CACJ"}

--- a/types/src/Marks/Link.d.ts
+++ b/types/src/Marks/Link.d.ts
@@ -1,0 +1,11 @@
+export = Link;
+declare class Link extends Mark {
+    tag(): {
+        tag: string;
+        attrs: {
+            href: any;
+        };
+    }[];
+}
+import Mark = require("./Mark");
+//# sourceMappingURL=Link.d.ts.map

--- a/types/src/Marks/Link.d.ts.map
+++ b/types/src/Marks/Link.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Link.d.ts","sourceRoot":"","sources":["../../../src/Marks/Link.js"],"names":[],"mappings":";AAEA;IAKI;;;;;QASC;CACJ"}

--- a/types/src/Marks/Mark.d.ts
+++ b/types/src/Marks/Mark.d.ts
@@ -1,0 +1,8 @@
+export = Mark;
+declare class Mark {
+    constructor(mark: any);
+    mark: any;
+    matching(): boolean;
+    tag(): any;
+}
+//# sourceMappingURL=Mark.d.ts.map

--- a/types/src/Marks/Mark.d.ts.map
+++ b/types/src/Marks/Mark.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Mark.d.ts","sourceRoot":"","sources":["../../../src/Marks/Mark.js"],"names":[],"mappings":";AAAA;IACI,uBAEC;IADG,UAAgB;IAGpB,oBAEC;IAED,WAEC;CACJ"}

--- a/types/src/Nodes/Blockquote.d.ts
+++ b/types/src/Nodes/Blockquote.d.ts
@@ -1,0 +1,6 @@
+export = Blockquote;
+declare class Blockquote extends Node {
+    tag(): string;
+}
+import Node = require("./Node");
+//# sourceMappingURL=Blockquote.d.ts.map

--- a/types/src/Nodes/Blockquote.d.ts.map
+++ b/types/src/Nodes/Blockquote.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Blockquote.d.ts","sourceRoot":"","sources":["../../../src/Nodes/Blockquote.js"],"names":[],"mappings":";AAEA;IAKI,cAEC;CACJ"}

--- a/types/src/Nodes/BulletList.d.ts
+++ b/types/src/Nodes/BulletList.d.ts
@@ -1,0 +1,6 @@
+export = BulletList;
+declare class BulletList extends Node {
+    tag(): string;
+}
+import Node = require("./Node");
+//# sourceMappingURL=BulletList.d.ts.map

--- a/types/src/Nodes/BulletList.d.ts.map
+++ b/types/src/Nodes/BulletList.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"BulletList.d.ts","sourceRoot":"","sources":["../../../src/Nodes/BulletList.js"],"names":[],"mappings":";AAEA;IAKI,cAEC;CACJ"}

--- a/types/src/Nodes/CodeBlock.d.ts
+++ b/types/src/Nodes/CodeBlock.d.ts
@@ -1,0 +1,8 @@
+export = CodeBlock;
+declare class CodeBlock extends Node {
+    tag(): {
+        tag: string;
+    }[];
+}
+import Node = require("./Node");
+//# sourceMappingURL=CodeBlock.d.ts.map

--- a/types/src/Nodes/CodeBlock.d.ts.map
+++ b/types/src/Nodes/CodeBlock.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"CodeBlock.d.ts","sourceRoot":"","sources":["../../../src/Nodes/CodeBlock.js"],"names":[],"mappings":";AAEA;IAKI;;QASC;CACJ"}

--- a/types/src/Nodes/Heading.d.ts
+++ b/types/src/Nodes/Heading.d.ts
@@ -1,0 +1,6 @@
+export = Heading;
+declare class Heading extends Node {
+    tag(): string;
+}
+import Node = require("./Node");
+//# sourceMappingURL=Heading.d.ts.map

--- a/types/src/Nodes/Heading.d.ts.map
+++ b/types/src/Nodes/Heading.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Heading.d.ts","sourceRoot":"","sources":["../../../src/Nodes/Heading.js"],"names":[],"mappings":";AAEA;IAKI,cAEC;CACJ"}

--- a/types/src/Nodes/Image.d.ts
+++ b/types/src/Nodes/Image.d.ts
@@ -1,0 +1,13 @@
+export = Image;
+declare class Image extends Node {
+    tag(): {
+        tag: string;
+        attrs: {
+            src: any;
+            alt: any;
+            title: any;
+        };
+    };
+}
+import Node = require("./Node");
+//# sourceMappingURL=Image.d.ts.map

--- a/types/src/Nodes/Image.d.ts.map
+++ b/types/src/Nodes/Image.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Image.d.ts","sourceRoot":"","sources":["../../../src/Nodes/Image.js"],"names":[],"mappings":";AAEA;IASI;;;;;;;MASC;CACJ"}

--- a/types/src/Nodes/ListItem.d.ts
+++ b/types/src/Nodes/ListItem.d.ts
@@ -1,0 +1,6 @@
+export = ItemList;
+declare class ItemList extends Node {
+    tag(): string;
+}
+import Node = require("./Node");
+//# sourceMappingURL=ListItem.d.ts.map

--- a/types/src/Nodes/ListItem.d.ts.map
+++ b/types/src/Nodes/ListItem.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"ListItem.d.ts","sourceRoot":"","sources":["../../../src/Nodes/ListItem.js"],"names":[],"mappings":";AAEA;IAKI,cAEC;CACJ"}

--- a/types/src/Nodes/Node.d.ts
+++ b/types/src/Nodes/Node.d.ts
@@ -1,0 +1,10 @@
+export = Node;
+declare class Node {
+    constructor(node: any);
+    node: any;
+    matching(): boolean;
+    selfClosing(): boolean;
+    tag(): any;
+    text(): any;
+}
+//# sourceMappingURL=Node.d.ts.map

--- a/types/src/Nodes/Node.d.ts.map
+++ b/types/src/Nodes/Node.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Node.d.ts","sourceRoot":"","sources":["../../../src/Nodes/Node.js"],"names":[],"mappings":";AAAA;IACI,uBAEC;IADG,UAAgB;IAGpB,oBAEC;IAED,uBAEC;IAED,WAEC;IAED,YAEC;CACJ"}

--- a/types/src/Nodes/OrderedList.d.ts
+++ b/types/src/Nodes/OrderedList.d.ts
@@ -1,0 +1,6 @@
+export = OrderedList;
+declare class OrderedList extends Node {
+    tag(): string;
+}
+import Node = require("./Node");
+//# sourceMappingURL=OrderedList.d.ts.map

--- a/types/src/Nodes/OrderedList.d.ts.map
+++ b/types/src/Nodes/OrderedList.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"OrderedList.d.ts","sourceRoot":"","sources":["../../../src/Nodes/OrderedList.js"],"names":[],"mappings":";AAEA;IAKI,cAEC;CACJ"}

--- a/types/src/Nodes/Paragraph.d.ts
+++ b/types/src/Nodes/Paragraph.d.ts
@@ -1,0 +1,6 @@
+export = Paragraph;
+declare class Paragraph extends Node {
+    tag(): string;
+}
+import Node = require("./Node");
+//# sourceMappingURL=Paragraph.d.ts.map

--- a/types/src/Nodes/Paragraph.d.ts.map
+++ b/types/src/Nodes/Paragraph.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Paragraph.d.ts","sourceRoot":"","sources":["../../../src/Nodes/Paragraph.js"],"names":[],"mappings":";AAEA;IAKI,cAEC;CACJ"}

--- a/types/src/Renderer.d.ts
+++ b/types/src/Renderer.d.ts
@@ -1,0 +1,16 @@
+export = Renderer;
+declare class Renderer {
+    document: any;
+    nodes: (typeof import("./Nodes/Blockquote") | typeof import("./Nodes/CodeBlock") | typeof import("./Nodes/Image"))[];
+    marks: (typeof import("./Marks/Bold") | typeof import("./Marks/Link"))[];
+    setDocument(value: any): void;
+    renderNode(node: any): any;
+    renderOpeningTag(tags: any): any;
+    renderClosingTag(tags: any): any;
+    render(value: any): string;
+    addNode(node: any): void;
+    addNodes(nodes: any): void;
+    addMark(mark: any): void;
+    addMarks(marks: any): void;
+}
+//# sourceMappingURL=Renderer.d.ts.map

--- a/types/src/Renderer.d.ts.map
+++ b/types/src/Renderer.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Renderer.d.ts","sourceRoot":"","sources":["../../src/Renderer.js"],"names":[],"mappings":";AAEA;IAEQ,cAAyB;IACzB,qHASC;IACD,yEAKC;IAGL,8BAQC;IAED,2BAkEC;IAED,iCAwBC;IAED,iCAeC;IAED,2BAWC;IAED,yBAEC;IAED,2BAIC;IAED,yBAEC;IAED,2BAIC;CACJ"}

--- a/types/src/utils.d.ts
+++ b/types/src/utils.d.ts
@@ -1,0 +1,3 @@
+export function htmlEntities(text: any): any;
+export function arrayify(element: any): any[];
+//# sourceMappingURL=utils.d.ts.map

--- a/types/src/utils.d.ts.map
+++ b/types/src/utils.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"utils.d.ts","sourceRoot":"","sources":["../../src/utils.js"],"names":[],"mappings":"AAA8B,6CAO7B;AAEyB,8CAMzB"}

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -1,0 +1,3 @@
+export function htmlEntities(text: any): any;
+export function arrayify(element: any): any[];
+//# sourceMappingURL=utils.d.ts.map

--- a/types/utils.d.ts.map
+++ b/types/utils.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"utils.d.ts","sourceRoot":"","sources":["../src/utils.js"],"names":[],"mappings":"AAA8B,6CAO7B;AAEyB,8CAMzB"}


### PR DESCRIPTION
This add typescript support by introducing a tsconfig.json file, and including
typescript as a dev dependency. Type definitions are genearted through a `npm
run types` and the type folder should be committed and published. The type
folder is referenced in the package.json as the root of the types. This isn't a
perfect definition as all the entries have "any" but it does enable typescript
usage.
